### PR TITLE
Add Travis CI configuration [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+
+matrix:
+  allow_failures:
+    - python: "nightly"
+
+python:
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "nightly"
+
+install:
+    - pip install -r requirements-selftests.txt
+
+script:
+    - inspekt indent
+    - inspekt style --exclude='.git' --disable='E501,E265,W601,E402,E722'

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -1,0 +1,4 @@
+# inspektor (static and style checks)
+pylint==1.9.3; python_version <= '2.7'
+pylint==2.2.0; python_version >= '3.4'
+inspektor==0.5.2


### PR DESCRIPTION
To basically make sure we don't regress with regards to code style.
When tests are added, we'll make sure to update the config to run
them.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#3 ):
 * Removed inspekt lint check, becase of the following errors on Python 2:
```
************* Module Cit
E0001:285,0: : invalid syntax (<string>, line 285)
Syntax check FAIL
The command "inspekt lint --exclude='.git' --enable='R0401,W0101,W0102,W0104,W0105,W0106,W0107,W0108,W0109,W0111,W0120,W0122,W0123,W0124,W0125,W0150,W0199,W0211,W0222,W0223,W0232,W0233,W0301,W0311,W0312,W0401,W0404,W0406,W0410,W0601,W0602,W0603,W0604,W0611,W0612,W0613,W0614,W0621,W0622,W0623,W0631,W0640,W0702,W0705,W0711,W1201,W1202,W1300,W1301,W1302,W1303,W1304,W1305,W1306,W1307,W1401,W1402,W1501,W1503,W1645'" exited with 1.
```