### PR TITLE
Drop Python 2 checks (and support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
     - python: "nightly"
 
 python:
-    - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -1,4 +1,3 @@
 # inspektor (static and style checks)
-pylint==1.9.3; python_version <= '2.7'
-pylint==2.2.0; python_version >= '3.4'
+pylint==2.2.0
 inspektor==0.5.2


### PR DESCRIPTION
Avocado is going to drop Python 2 support, so it's natural that we
don't try to support it here too.

Signed-off-by: Cleber Rosa <crosa@redhat.com>